### PR TITLE
Calculate fog fade in/out using the ShowLighterFog target alpha when enabled

### DIFF
--- a/ClimatesOfFerngill/CustomWeathers/FerngillFog.cs
+++ b/ClimatesOfFerngill/CustomWeathers/FerngillFog.cs
@@ -108,8 +108,8 @@ namespace ClimatesOfFerngillRebuild
         {
             ExpirTime = new SDVTime(SDVTime.CurrentTime - 10);
             CurrentFogType = FogType.None;
-            FogElapsed.Start();
             FadeOutFog = true;
+            FogElapsed.Start();
             UpdateStatus(WeatherType, false);
         }
 
@@ -208,8 +208,8 @@ namespace ClimatesOfFerngillRebuild
             {
                 ExpirTime = new SDVTime(SDVTime.CurrentTime - 10);
                 CurrentFogType = FogType.None;
-                FogElapsed.Start();
                 FadeOutFog = true;
+                FogElapsed.Start();
                 UpdateStatus(WeatherType, false);
             }
         }

--- a/ClimatesOfFerngill/CustomWeathers/FerngillFog.cs
+++ b/ClimatesOfFerngill/CustomWeathers/FerngillFog.cs
@@ -17,7 +17,7 @@ namespace ClimatesOfFerngillRebuild
         /// <summary> The Current Fog Type </summary>
         internal FogType CurrentFogType { get; set; }
         public bool BloodMoon { get; set; }
-        /// <summary> The alpha attribute of the fog. </summary>
+        /// <summary> The currently-shown alpha attribute of the fog. </summary>
         private float FogAlpha { get; set; }
         /// <summary> Fog Position. For drawing. </summary>
         private Vector2 FogPosition { get; set; }

--- a/ClimatesOfFerngill/CustomWeathers/FerngillFog.cs
+++ b/ClimatesOfFerngill/CustomWeathers/FerngillFog.cs
@@ -109,6 +109,7 @@ namespace ClimatesOfFerngillRebuild
             ExpirTime = new SDVTime(SDVTime.CurrentTime - 10);
             CurrentFogType = FogType.None;
             FadeOutFog = true;
+            SetFogTargetAlpha();
             FogElapsed.Start();
             UpdateStatus(WeatherType, false);
         }
@@ -209,6 +210,7 @@ namespace ClimatesOfFerngillRebuild
                 ExpirTime = new SDVTime(SDVTime.CurrentTime - 10);
                 CurrentFogType = FogType.None;
                 FadeOutFog = true;
+                SetFogTargetAlpha();
                 FogElapsed.Start();
                 UpdateStatus(WeatherType, false);
             }
@@ -234,6 +236,7 @@ namespace ClimatesOfFerngillRebuild
             {            
                 CurrentFogType = FogType.Normal;
                 FadeInFog = true;
+                SetFogTargetAlpha();
                 FogElapsed.Start();
                 UpdateStatus(WeatherType, true);
             }
@@ -241,6 +244,7 @@ namespace ClimatesOfFerngillRebuild
             if (SDVTime.CurrentTime >= WeatherExpirationTime && IsWeatherVisible)
             {
                 FadeOutFog = true;
+                SetFogTargetAlpha();
                 FogElapsed.Start();
                 UpdateStatus(WeatherType, false);
             }
@@ -319,11 +323,12 @@ namespace ClimatesOfFerngillRebuild
                 // So, 3000ms for 55% or 54.45 repeating. But this is super fast....
                 // let's try 955ms.. or 1345..
                 // or 2690.. so no longer 3s. :<
-                FogAlpha = 1 - (FogElapsed.ElapsedMilliseconds / FogFadeTime);
+                FogAlpha = FogTargetAlpha * (1 - (FogElapsed.ElapsedMilliseconds / FogFadeTime));
                
                 if (FogAlpha <= 0)
                 {
                     FogAlpha = 0;
+                    FogTargetAlpha = 0;
                     CurrentFogType = FogType.None;
                     FadeOutFog = false;
                     FogElapsed.Stop();
@@ -334,10 +339,10 @@ namespace ClimatesOfFerngillRebuild
             if (FadeInFog)
             {
                 //as above, but the reverse.
-                FogAlpha = (FogElapsed.ElapsedMilliseconds / FogFadeTime);
-                if (FogAlpha >= 1)
+                FogAlpha = FogTargetAlpha * (FogElapsed.ElapsedMilliseconds / FogFadeTime);
+                if (FogAlpha >= FogTargetAlpha)
                 {
-                    FogAlpha = 1;
+                    FogAlpha = FogTargetAlpha;
                     FadeInFog = false;
                     FogElapsed.Stop();
                     FogElapsed.Reset();

--- a/ClimatesOfFerngill/CustomWeathers/FerngillFog.cs
+++ b/ClimatesOfFerngill/CustomWeathers/FerngillFog.cs
@@ -17,7 +17,7 @@ namespace ClimatesOfFerngillRebuild
         /// <summary> The Current Fog Type </summary>
         internal FogType CurrentFogType { get; set; }
         public bool BloodMoon { get; set; }
-        /// <summary>  The alpha attribute of the fog. </summary>
+        /// <summary> The alpha attribute of the fog. </summary>
         private float FogAlpha { get; set; }
         /// <summary> Fog Position. For drawing. </summary>
         private Vector2 FogPosition { get; set; }

--- a/ClimatesOfFerngill/CustomWeathers/FerngillFog.cs
+++ b/ClimatesOfFerngill/CustomWeathers/FerngillFog.cs
@@ -17,6 +17,8 @@ namespace ClimatesOfFerngillRebuild
         /// <summary> The Current Fog Type </summary>
         internal FogType CurrentFogType { get; set; }
         public bool BloodMoon { get; set; }
+        /// <summary> The calculated alpha attribute of fog to use when fading fog in/out. </summary>
+        private float FogTargetAlpha { get; set; }
         /// <summary> The currently-shown alpha attribute of the fog. </summary>
         private float FogAlpha { get; set; }
         /// <summary> Fog Position. For drawing. </summary>
@@ -45,6 +47,20 @@ namespace ClimatesOfFerngillRebuild
         private bool FadeOutFog { get; set; }
         private bool FadeInFog { get; set; }
         private Stopwatch FogElapsed { get; set; }
+        public void SetFogTargetAlpha()
+        {
+            if (ClimatesOfFerngill.WeatherOpt.ShowLighterFog)
+            {
+                if (Game1.isRaining)
+                    this.FogTargetAlpha = .2f;
+                else
+                    this.FogTargetAlpha = .3f;
+            }
+            else
+            {
+                this.FogTargetAlpha = 1f;
+            }
+        }
 
         /// <summary> Default constructor. </summary>
         internal FerngillFog(SDVTimePeriods FogPeriod)
@@ -71,6 +87,7 @@ namespace ClimatesOfFerngillRebuild
             ExpirTime = new SDVTime(0600);
             BloodMoon = false;
             FogAlpha = 0f;
+            FogTargetAlpha = 0f;
             FadeOutFog = false;
             FadeInFog = false;
             FogElapsed.Reset(); 

--- a/ClimatesOfFerngill/CustomWeathers/FerngillFog.cs
+++ b/ClimatesOfFerngill/CustomWeathers/FerngillFog.cs
@@ -95,16 +95,9 @@ namespace ClimatesOfFerngillRebuild
 
         public void ForceWeatherStart()
         {
-            this.FogAlpha = 1f;
+            SetFogTargetAlpha();
+            this.FogAlpha = this.FogTargetAlpha;
             CurrentFogType = FogType.Normal;
-
-            if (ClimatesOfFerngill.WeatherOpt.ShowLighterFog)
-            {
-                if (Game1.isRaining) 
-                    this.FogAlpha = .2f;
-                else
-                    this.FogAlpha = .3f;
-            }
 
 
             
@@ -154,16 +147,9 @@ namespace ClimatesOfFerngillRebuild
         /// <summary>This function creates the fog </summary>
         public void CreateWeather()
         {
-            this.FogAlpha = 1f;
+            SetFogTargetAlpha();
+            this.FogAlpha = this.FogTargetAlpha;
             CurrentFogType = FogType.Normal;
-
-            if (ClimatesOfFerngill.WeatherOpt.ShowLighterFog)
-            {
-                if (Game1.isRaining)
-                    this.FogAlpha = .2f;
-                else
-                    this.FogAlpha = .3f;
-            }
 
             //now determine the fog expiration time
             double FogChance = ClimatesOfFerngill.Dice.NextDoublePositive();


### PR DESCRIPTION
When `ShowLighterFog` is enabled in config.json, the default fog target alpha of 100% opacity is replaced with either 20% (if it's raining) or else 30%.

However, the fog fade in/out still assumes that it's fading to/from 100%, which causes a bright white flash when the fog fades out during the day (as the fade jumps from 20/30% to 100% in order to fade to 0%).

This _untested_ pull request moves the 'target alpha' logic into a central location and then updates the fog fade in/out logic to multiply by the target opacity. (I hesitated to just call GetWeather 3000 times in 3 seconds in the fade loops, but if that's cheap/free/performs-well, that would be a simpler patch.)

I don't know how to recompile all of this to test it myself but I wanted to share the bug report and possible approach to fixing it. There might be a better/simpler/etc. way to do it or a reason not to do it, in which case I defer to your judgement :)

Thanks for the weather mod. Be well.